### PR TITLE
Fix the link in version 0.2.0 of the changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -111,7 +111,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 * Not used dependencies.
 
-[unreleased]: https://github.com/QISKit/qiskit-sdk-js/compare/v0.1.9...HEAD
+[unreleased]: https://github.com/QISKit/qiskit-sdk-js/compare/v0.2.0...HEAD
 [0.2.0]: https://github.com/QISKit/qiskit-sdk-js/compare/v0.1.9...v0.2.0
 [0.1.9]: https://github.com/QISKit/qiskit-sdk-js/compare/v0.1.8...v0.1.9
 [0.1.8]: https://github.com/QISKit/qiskit-sdk-js/compare/v0.1.7...v0.1.8

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -112,6 +112,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 * Not used dependencies.
 
 [unreleased]: https://github.com/QISKit/qiskit-sdk-js/compare/v0.1.9...HEAD
+[0.2.0]: https://github.com/QISKit/qiskit-sdk-js/compare/v0.1.9...v0.2.0
 [0.1.9]: https://github.com/QISKit/qiskit-sdk-js/compare/v0.1.8...v0.1.9
 [0.1.8]: https://github.com/QISKit/qiskit-sdk-js/compare/v0.1.7...v0.1.8
 [0.1.7]: https://github.com/QISKit/qiskit-sdk-js/compare/v0.1.6...v0.1.7


### PR DESCRIPTION
The link in the [0.2.0] version does not appear in the current changelog. This PR fixes that, as it includes the link at the end of the file comparing the version 0.1.9 and 0.2.0